### PR TITLE
Rule Linting

### DIFF
--- a/Example/Rules.xcodeproj/project.pbxproj
+++ b/Example/Rules.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		380088CD20EAF2EB006AA5E2 /* PredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380088CC20EAF2EB006AA5E2 /* PredicateTests.swift */; };
 		380088CF20EBD1EF006AA5E2 /* RuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 380088CE20EBD1EF006AA5E2 /* RuleTests.swift */; };
+		38BC676B2127692400F4382C /* LintingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BC676A2127692400F4382C /* LintingTests.swift */; };
 		607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD51AFB9204008FA782 /* AppDelegate.swift */; };
 		607FACD81AFB9204008FA782 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACD71AFB9204008FA782 /* ViewController.swift */; };
 		607FACDB1AFB9204008FA782 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 607FACD91AFB9204008FA782 /* Main.storyboard */; };
@@ -33,6 +34,7 @@
 		003F295B1317ED2C6AF9F1D9 /* Pods_Rules_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rules_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		380088CC20EAF2EB006AA5E2 /* PredicateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PredicateTests.swift; sourceTree = "<group>"; };
 		380088CE20EBD1EF006AA5E2 /* RuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RuleTests.swift; sourceTree = "<group>"; };
+		38BC676A2127692400F4382C /* LintingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LintingTests.swift; sourceTree = "<group>"; };
 		39ACB4D10B7FF040EB330BE5 /* Pods-Rules_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Rules_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Rules_Example/Pods-Rules_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		4618D76955E7F156F678EF7A /* Pods_Rules_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Rules_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		537D77E2EF80A044A641133A /* Rules.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Rules.podspec; path = ../Rules.podspec; sourceTree = "<group>"; };
@@ -120,6 +122,7 @@
 			isa = PBXGroup;
 			children = (
 				607FACEB1AFB9204008FA782 /* FactsTests.swift */,
+				38BC676A2127692400F4382C /* LintingTests.swift */,
 				380088CC20EAF2EB006AA5E2 /* PredicateTests.swift */,
 				380088CE20EBD1EF006AA5E2 /* RuleTests.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
@@ -391,6 +394,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				380088CF20EBD1EF006AA5E2 /* RuleTests.swift in Sources */,
+				38BC676B2127692400F4382C /* LintingTests.swift in Sources */,
 				607FACEC1AFB9204008FA782 /* FactsTests.swift in Sources */,
 				380088CD20EAF2EB006AA5E2 /* PredicateTests.swift in Sources */,
 			);

--- a/Example/Tests/LintingTests.swift
+++ b/Example/Tests/LintingTests.swift
@@ -1,0 +1,96 @@
+//
+//  LintingTests.swift
+//  Rules
+//  License: MIT, included below
+//
+
+// deal with Quick/Nimble naming conflict
+@testable import enum Rules.Predicate
+
+import Quick
+import Nimble
+
+@testable import Rules
+
+class LintingTests: QuickSpec {
+    override func spec() {
+
+        describe("Linting") {
+
+            describe("linter(parsed:spec:)") {
+                it("does not find lint when there are no rules and no spec") {
+                    expect(linter(parsed: [], spec: nil) == []).to(beTrue())
+                }
+            }
+
+            describe("checkFallbackRulesExist(parsed:spec:)") {
+                it("finds lint when there are no rules but there are rhs questions specified") {
+                    let spec = LinterSpecification(lhs: [:], rhs: ["aQuestion": .any])
+                    expect(checkFallbackRulesExist(parsed: [], spec: spec) == [(nil, "no fallback rule found for aQuestion")]).to(beTrue())
+                }
+                it("finds lint when there is a rule but it isn't a fallback rule") {
+                    let spec = LinterSpecification(lhs: [:], rhs: ["aQuestion": .any])
+                    let parsed = ParsedHumanRule(
+                        lineNumber: 1,
+                        line: "10: this = 'that' => aQuestion = answer",
+                        rule: .init(
+                            priority: 10,
+                            predicate: .comparison(lhs: .question("this"), op: .isEqualTo, rhs: .answer(.init(comparable: "that"))),
+                            question: "aQuestion",
+                            answer: "answer",
+                            assignment: nil
+                        )
+                    )
+                    expect(checkFallbackRulesExist(parsed: [parsed], spec: spec) == [(nil, "no fallback rule found for aQuestion")]).to(beTrue())
+                }
+                it("does not find lint when there is a rule and it is a fallback rule") {
+                    let spec = LinterSpecification(lhs: [:], rhs: ["aQuestion": .any])
+                    let parsed = ParsedHumanRule(
+                        lineNumber: 1,
+                        line: "0: true => aQuestion = answer",
+                        rule: .init(
+                            priority: 0,
+                            predicate: .true,
+                            question: "aQuestion",
+                            answer: "answer",
+                            assignment: nil
+                        )
+                    )
+                    expect(checkFallbackRulesExist(parsed: [parsed], spec: spec).isEmpty).to(beTrue())
+                }
+            }
+        }
+    }
+}
+
+func == (lhs: RuleLint, rhs: RuleLint) -> Bool {
+    return lhs.0 == rhs.0
+        && lhs.1 == rhs.1
+}
+
+func == (lhs: [RuleLint], rhs: [RuleLint]) -> Bool {
+    return lhs.count == rhs.count
+        && zip(lhs, rhs).reduce(true) { result, pair in result && (pair.0 == pair.1) }
+}
+
+//  Created by Jim Roepcke on 2018-06-24.
+//  Copyright © 2018- Jim Roepcke.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+//

--- a/Example/Tests/RuleTests.swift
+++ b/Example/Tests/RuleTests.swift
@@ -78,7 +78,7 @@ class RuleTests: QuickSpec {
                         answer: "roepcke",
                         assignment: nil
                     )
-                    expect(parse(humanRuleFileContents: sut)) == .success([expected])
+                    expect(parse(humanRuleFileContents: sut)) == .success([.init(lineNumber: 1, line: sut, rule: expected)])
                 }
 
                 it("parses a file with two lines") {
@@ -91,7 +91,9 @@ class RuleTests: QuickSpec {
                         answer: "roepcke",
                         assignment: nil
                     )
-                    expect(parse(humanRuleFileContents: sut)) == .success([expected, expected])
+                    let parsed1 = ParsedHumanRule(lineNumber: 1, line: line, rule: expected)
+                    let parsed2 = ParsedHumanRule(lineNumber: 2, line: line, rule: expected)
+                    expect(parse(humanRuleFileContents: sut)) == .success([parsed1, parsed2])
                 }
 
                 it("parses a file with two lines and comments") {
@@ -104,7 +106,9 @@ class RuleTests: QuickSpec {
                         answer: "roepcke",
                         assignment: nil
                     )
-                    expect(parse(humanRuleFileContents: sut)) == .success([expected, expected])
+                    let parsed2 = ParsedHumanRule(lineNumber: 2, line: line, rule: expected)
+                    let parsed4 = ParsedHumanRule(lineNumber: 4, line: line, rule: expected)
+                    expect(parse(humanRuleFileContents: sut)) == .success([parsed2, parsed4])
                 }
             }
         }

--- a/Rules/Sources/Rules/Brain.swift
+++ b/Rules/Sources/Rules/Brain.swift
@@ -148,7 +148,7 @@ public class Brain {
     }
 
     /// This is basically a `String`, but it's more type-safe.
-    public struct Assignment: Hashable, Codable, ExpressibleByStringLiteral {
+    public struct Assignment: Hashable, Codable, ExpressibleByStringLiteral, CustomStringConvertible, CustomDebugStringConvertible {
         public let identifier: String
 
         public typealias StringLiteralType = String
@@ -170,6 +170,9 @@ public class Brain {
             var container = encoder.singleValueContainer()
             try container.encode(identifier)
         }
+
+        public var description: String { return identifier }
+        public var debugDescription: String { return identifier }
     }
 
     /// If an `Assignment` cannot provide a `Facts.AnswerWithDependencies`, it

--- a/Rules/Sources/Rules/Facts.swift
+++ b/Rules/Sources/Rules/Facts.swift
@@ -35,7 +35,7 @@ public class Facts {
     }
 
     /// This is basically a `String`, but it's more type-safe.
-    public struct Question: Hashable, Codable, ExpressibleByStringLiteral {
+    public struct Question: Hashable, Codable, ExpressibleByStringLiteral, CustomStringConvertible, CustomDebugStringConvertible {
         public let identifier: String
 
         public typealias StringLiteralType = String
@@ -57,6 +57,9 @@ public class Facts {
             var container = encoder.singleValueContainer()
             try container.encode(identifier)
         }
+
+        public var description: String { return identifier }
+        public var debugDescription: String { return identifier }
     }
 
     /// A `value` provided to `Facts` either by:

--- a/Rules/Sources/Rules/Linting.swift
+++ b/Rules/Sources/Rules/Linting.swift
@@ -1,0 +1,246 @@
+//
+//  Linting.swift
+//  Rules
+//  License: MIT, included below
+//
+
+enum AnswerConstraint: Equatable {
+    case strings([String])
+    case string
+    case bool
+    case int
+    case double
+    case any
+}
+
+extension AnswerConstraint: Decodable {
+    enum AnswerConstraintDecodingError: String, Error {
+        case unexpectedValue
+    }
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        do {
+            self = .strings(try container.decode([String].self))
+        } catch {
+            switch try container.decode(String.self) {
+            case "string": self = .string
+            case "bool": self = .bool
+            case "int": self = .int
+            case "double": self = .double
+            case "any": self = .any
+            default:
+                throw AnswerConstraintDecodingError.unexpectedValue
+            }
+        }
+    }
+}
+
+struct LinterSpecification: Equatable, Decodable {
+    let lhs: [String: AnswerConstraint]
+    let rhs: [String: AnswerConstraint]
+}
+
+typealias RuleLint = (ParsedHumanRule?, String)
+
+func linter(parsed values: [ParsedHumanRule], spec: LinterSpecification?) -> [RuleLint] {
+    return checkDuplicates(parsed: values)
+        + checkPredicates(parsed: values)
+        + (spec.map { checkSpecification(parsed: values, spec: $0) } ?? [])
+}
+
+func checkDuplicates(parsed values: [ParsedHumanRule]) -> [RuleLint] {
+    return values.reduce((rules: Set<String>(), errors: [RuleLint]()), { result, value in
+        (
+            result.rules.union([value.line]),
+            result.errors + (result.rules.contains(value.line) ? [(value, "duplicate rule found")] : [])
+        )
+    }).errors
+}
+
+func checkPredicates(parsed values: [ParsedHumanRule]) -> [RuleLint] {
+    func isValid(predicate: Predicate) -> String? {
+        // these cases correspond to the cases of `evaluate(predicate:given:)` that
+        // immediately return `.failed`.
+        switch predicate {
+        case .comparison(.predicate, .isLessThan, _),
+             .comparison(.predicate, .isGreaterThan, _),
+             .comparison(.predicate, .isGreaterThanOrEqualTo, _),
+             .comparison(.predicate, .isLessThanOrEqualTo, _),
+             .comparison(_, .isLessThan, .predicate),
+             .comparison(_, .isGreaterThan, .predicate),
+             .comparison(_, .isGreaterThanOrEqualTo, .predicate),
+             .comparison(_, .isLessThanOrEqualTo, .predicate):
+            return "invalid predicate: boolean values are not comparable"
+        case .comparison(.predicate, _, .answer),
+             .comparison(.answer, _, .predicate):
+            return "invalid predicate: type mismatch"
+        default:
+            return nil
+        }
+    }
+    return values
+        .map { p in isValid(predicate: p.rule.predicate).map { (.some(p), "\($0)") } }
+        .compactMap(Rules.id)
+}
+
+func checkSpecification(parsed values: [ParsedHumanRule], spec: LinterSpecification) -> [RuleLint] {
+    return [
+        checkAllRHSQuestionsAreValid,
+        checkFallbackRulesExist,
+        checkRHSAnswerTypeIsCorrect,
+        checkLHSAnswerTypesAreCorrect
+        ]
+        .flatMap { $0(values, spec) }
+}
+
+func checkAllRHSQuestionsAreValid(parsed values: [ParsedHumanRule], spec: LinterSpecification) -> [RuleLint] {
+    let questions = Set(spec.rhs.keys)
+    func check(value: ParsedHumanRule) -> RuleLint? {
+        return questions.contains(value.rule.question.identifier)
+            ? nil
+            : (.init(value), "rhs question \(value.rule.question.identifier) not found in the linter file")
+    }
+    return values
+        .map(check)
+        .compactMap(Rules.id)
+}
+
+func checkFallbackRulesExist(parsed values: [ParsedHumanRule], spec: LinterSpecification) -> [RuleLint] {
+    func hasFallbackRule(rhs: String) -> RuleLint? {
+        return values.contains { $0.rule.question.identifier == rhs && $0.rule.predicate == .true && $0.rule.priority == 0 }
+            ? nil
+            : (nil, "no fallback rule found for \(rhs)")
+    }
+    return spec.rhs.keys
+        .map(hasFallbackRule)
+        .compactMap(Rules.id)
+}
+
+func checkRHSAnswerTypeIsCorrect(parsed values: [ParsedHumanRule], spec: LinterSpecification) -> [RuleLint] {
+    func constraint(_ pair: (key: String, value: AnswerConstraint), matches value: ParsedHumanRule) -> RuleLint? {
+        guard value.rule.question.identifier == pair.key else {
+            return nil
+        }
+        let rule = value.rule
+        switch pair.value {
+        case .any:
+            return nil
+        case .strings(let strings):
+            return strings.contains(rule.answer)
+                ? nil
+                : (.init(value), "the answer for \(rule.question.identifier) rules must be one of: \(strings.joined(separator: ", "))")
+        case .string:
+            return rule.assignment.map { (value, "rule with question \(rule.question.identifier) expected to have a string answer, but it has an assignment specified: \($0). Remove the assignment to use the default assignment which results in a string answer") }
+        case .bool,
+             .int,
+             .double:
+            return (value, "constraining rule with question \(rule.question.identifier) to non-string answers is not currently supported because parsing assignments from human rule files has not been implemented yet")
+        }
+    }
+    func hasCorrectRHSAnswerType(pair: (key: String, value: AnswerConstraint)) -> [RuleLint] {
+        return values
+            .compactMap { constraint(pair, matches: $0) }
+    }
+    return spec.rhs
+        .flatMap(hasCorrectRHSAnswerType)
+        .compactMap(Rules.id)
+}
+
+func checkLHSAnswerTypesAreCorrect(parsed values: [ParsedHumanRule], spec: LinterSpecification) -> [RuleLint] {
+    func typeName<T>(of x: T) -> String {
+        return String(describing: type(of: x)).lowercased()
+    }
+    func checkConstraint(for question: Facts.Question, and answer: Facts.Answer, value: ParsedHumanRule) -> [RuleLint] {
+        guard let constraint = spec.lhs[question.identifier] else {
+            return [(value, "lhs question \(question) not found in the linter file")]
+        }
+        switch (constraint, answer.value) {
+        case (.any, _),
+             (.int, is Int),
+             (.double, is Double),
+             (.string, is String): return []
+        case (.bool, let x): return [(value, "type mismatch, \(question) should be compared to a bool, not a \(typeName(of: x))")]
+        case (.int, let x): return [(value, "type mismatch, \(question) should be compared to an int, not a \(typeName(of: x))")]
+        case (.double, let x): return [(value, "type mismatch, \(question) should be compared to a double, not a \(typeName(of: x))")]
+        case (.string, let x): return [(value, "type mismatch, \(question) should be compared to a string, not a \(typeName(of: x))")]
+        case (.strings(let strings), let x as String) where strings.contains(x): return []
+        case (.strings(let strings), is String): return [(value, "\(question) may only be compared to one of: \(strings.joined(separator: ", "))")]
+        case (.strings, let x): return [(value, "type mismatch, \(question) should be compared to a string, not a \(typeName(of: x))")]
+        }
+    }
+    func check(predicate: Predicate, value: ParsedHumanRule) -> [RuleLint] {
+        switch predicate {
+        case .false, .true: return []
+        case .not(let p):
+            return check(predicate: p, value: value)
+        case .and(let ps), .or(let ps):
+            return ps.flatMap { check(predicate: $0, value: value) }
+        case .comparison(.predicate(let left), _, .predicate(let right)):
+            return check(predicate: left, value: value)
+                + check(predicate: right, value: value)
+        case .comparison(.question(let question), _, .predicate(let p)),
+             .comparison(.predicate(let p), _, .question(let question)):
+            let ps = check(predicate: p, value: value)
+            guard let constraint = spec.lhs[question.identifier] else {
+                return ps + [(value, "lhs question \(question) not found in the linter file")]
+            }
+            switch constraint {
+            case .any, .bool: return ps
+            case .int:
+                return ps + [(value, "type mismatch, \(question) should be an int but it is being compared to a bool")]
+            case .double:
+                return ps + [(value, "type mismatch, \(question) should be a double but it is being compared to a bool")]
+            case .string, .strings:
+                return ps + [(value, "type mismatch, \(question) should be a string but it is being compared to a bool")]
+            }
+        case .comparison(.answer(let answer), _, .predicate) where answer.value is Bool:
+            return []
+        case .comparison(.answer(let answer), _, .predicate):
+            return [(value, "type mismatch, comparing a \(typeName(of: answer.value)) to a bool")]
+        case .comparison(.predicate, _, .answer(let answer)) where answer.value is Bool:
+            return []
+        case .comparison(.predicate, _, .answer(let answer)):
+            return [(value, "type mismatch, comparing a \(typeName(of: answer.value)) to a bool")]
+        case .comparison(.question(let question), _, .answer(let answer)):
+            return checkConstraint(for: question, and: answer, value: value)
+        case .comparison(.answer(let answer), _, .question(let question)):
+            return checkConstraint(for: question, and: answer, value: value)
+        case .comparison(.question, _, .question):
+            return [] // not yet implemented
+        case .comparison(.answer(let left), _, .answer(let right)) where type(of: left.value) == type(of: right.value):
+            // it could be argued this shouldn't be allowed because it's silly
+            // 8 == 8, 8 == 4, 8 < 4, 8 > 4, these are all constants and
+            // should not be a part of a rules file
+            return []
+        case .comparison(.answer(let left), _, .answer(let right)):
+            return [(value, "type mismatch, comparing a \(typeName(of: left.value)) to a \(typeName(of: right.value))")]
+        }
+    }
+    func checkLHS(value: ParsedHumanRule) -> [RuleLint] {
+        return check(predicate: value.rule.predicate, value: value)
+    }
+    return values
+        .flatMap(checkLHS)
+}
+
+//  Created by Jim Roepcke on 2018-06-24.
+//  Copyright © 2018- Jim Roepcke.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to
+//  deal in the Software without restriction, including without limitation the
+//  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+//  sell copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+//  IN THE SOFTWARE.
+//

--- a/TextRulesToJSON/Fixtures/linter-tests/fixture.rules
+++ b/TextRulesToJSON/Fixtures/linter-tests/fixture.rules
@@ -1,0 +1,8 @@
+0: true => favouriteTeam = X
+10: (firstName = 'Jim' AND lastName = 'Roepcke') OR (city = 'Edmonton') => favouriteTeam = Oilers
+10: (firstName = 'Xavier' AND lastName = 'Roepcke') OR (city = 'Tampa Bay') => favouriteTeam = Lightning
+10: (firstName = 'Bob' AND lastName = 'Roepcke') OR (city = 'Tampa Bay') => favouriteTeam = Lightning
+10: firstName < true => shouldnot = work
+10: true < true => shouldnot = workeither
+10: true < true => shouldnot = workeither
+10: age < 10 => kid = true

--- a/TextRulesToJSON/Fixtures/linter-tests/linter.json
+++ b/TextRulesToJSON/Fixtures/linter-tests/linter.json
@@ -1,0 +1,11 @@
+{
+  "lhs": {
+    "firstName": ["Jim", "Cheryl", "Cyan", "Xavier"],
+    "lastName": "string",
+    "age": "int"
+  },
+  "rhs": {
+    "favouriteTeam": ["Capitals", "Oilers", "Lightning", "Canucks"],
+    "favouritePlayer": "any"
+  }
+}

--- a/TextRulesToJSON/Fixtures/linter.json
+++ b/TextRulesToJSON/Fixtures/linter.json
@@ -1,0 +1,10 @@
+{
+  "lhs": {
+    "firstName": ["Jim", "Cheryl", "Cyan", "Xavier"],
+    "lastName": "string",
+    "city": "string"
+  },
+  "rhs": {
+    "favouriteTeam": ["Capitals", "Oilers", "Lightning", "Canucks"]
+  }
+}

--- a/TextRulesToJSON/TextRulesToJSON.xcodeproj/project.pbxproj
+++ b/TextRulesToJSON/TextRulesToJSON.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		384741DA20FAC05800768E5E /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384741D920FAC05800768E5E /* main.swift */; };
+		38BC676921262C4400F4382C /* Linting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38BC676821262C4400F4382C /* Linting.swift */; };
 		FABBC52E21124F1200D66AEB /* Facts.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABBC52921124F1200D66AEB /* Facts.swift */; };
 		FABBC52F21124F1200D66AEB /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABBC52A21124F1200D66AEB /* Predicate.swift */; };
 		FABBC53021124F1200D66AEB /* Rule.swift in Sources */ = {isa = PBXBuildFile; fileRef = FABBC52B21124F1200D66AEB /* Rule.swift */; };
@@ -30,6 +31,7 @@
 /* Begin PBXFileReference section */
 		384741D620FAC05800768E5E /* TextRulesToJSON */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = TextRulesToJSON; sourceTree = BUILT_PRODUCTS_DIR; };
 		384741D920FAC05800768E5E /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		38BC676821262C4400F4382C /* Linting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Linting.swift; path = ../../Rules/Sources/Rules/Linting.swift; sourceTree = "<group>"; };
 		FABBC52921124F1200D66AEB /* Facts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Facts.swift; path = ../../Rules/Sources/Rules/Facts.swift; sourceTree = "<group>"; };
 		FABBC52A21124F1200D66AEB /* Predicate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Predicate.swift; path = ../../Rules/Sources/Rules/Predicate.swift; sourceTree = "<group>"; };
 		FABBC52B21124F1200D66AEB /* Rule.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Rule.swift; path = ../../Rules/Sources/Rules/Rule.swift; sourceTree = "<group>"; };
@@ -70,6 +72,7 @@
 				384741D920FAC05800768E5E /* main.swift */,
 				FABBC52D21124F1200D66AEB /* Brain.swift */,
 				FABBC52921124F1200D66AEB /* Facts.swift */,
+				38BC676821262C4400F4382C /* Linting.swift */,
 				FABBC52A21124F1200D66AEB /* Predicate.swift */,
 				FABBC52B21124F1200D66AEB /* Rule.swift */,
 				FABBC52C21124F1200D66AEB /* Rules.swift */,
@@ -135,6 +138,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				384741DA20FAC05800768E5E /* main.swift in Sources */,
+				38BC676921262C4400F4382C /* Linting.swift in Sources */,
 				FABBC53021124F1200D66AEB /* Rule.swift in Sources */,
 				FABBC52F21124F1200D66AEB /* Predicate.swift in Sources */,
 				FABBC52E21124F1200D66AEB /* Facts.swift in Sources */,

--- a/TextRulesToJSON/TextRulesToJSON/main.swift
+++ b/TextRulesToJSON/TextRulesToJSON/main.swift
@@ -8,45 +8,136 @@
 
 import Foundation
 
-func main(argc: Int32, argv: [String]) -> Int32 {
-    guard argc == 2 else {
-        print("TextRulesToJSON: usage -- TextRulesToJSON <TextRulesPath>")
-        return 1
-    }
-    let inputPath = argv[1]
-    guard FileManager.default.fileExists(atPath: inputPath) else {
-        print("TextRulesToJSON: file not found: \(inputPath)")
-        return 2
-    }
-    var result: Int32 = 0
-    var message = ""
-    do {
-        result = 3
-        message = "reading input failed"
-        let contents = try String(contentsOf: URL(fileURLWithPath: inputPath), encoding: .utf8)
-        let parsingResult = parse(humanRuleFileContents: contents)
-        switch parsingResult {
-        case .failed(let errors):
-            for error in errors {
-                print("TextRulesToJSON: \(error)")
-            }
-            result = 0
-        case .success(let rules):
-            result = 4
-            message = "encoding rules failed"
-            let data = try JSONEncoder().encode(rules)
-            result = 0
-            message = ""
-            guard let string = String.init(data: data, encoding: .utf8) else {
-                print("TextRulesToJSON: could not encode JSON data as UTF8 string")
-                return 5
-            }
-            print(string)
-        }
-    } catch let error {
-        print("TextRulesToJSON: \(message): \(error)")
-    }
-    return result
+func printToStdErr(_ s: String, preamble: String = "TextRulesToJSON: ") {
+    FileHandle.standardError.write(.init(bytes: Array(preamble.utf8)))
+    FileHandle.standardError.write(.init(bytes: Array(s.utf8)))
+    FileHandle.standardError.write(.init(bytes: Array("\n".utf8)))
 }
 
-exit(main(argc: CommandLine.argc, argv: CommandLine.arguments))
+func dataOf(path: String) -> Rules.Result<Error, Data> {
+    do {
+        return .success(try Data(contentsOf: URL(fileURLWithPath: path)))
+    } catch {
+        return .failed(error)
+    }
+}
+
+func contentsOf(path: String) -> Rules.Result<Error, String> {
+    do {
+        return .success(try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8))
+    } catch {
+        return .failed(error)
+    }
+}
+
+enum ExitCode: Int32 {
+    case success = 0
+    case usage = 1
+    case inputFileNotFound = 2
+    case linterFileNotFound = 3
+    case readingInputFileFailed = 4
+    case readingLinterFileFailed = 5
+    case decodingLinterFileFailed = 6
+    case parsingFailed = 7
+    case invalidRules = 8
+    case encodingToJSONFailed = 9
+}
+
+struct Environment: Equatable {
+    var input: String = ""
+    var linterSpecification: LinterSpecification?
+}
+
+private var Current = Environment()
+
+func configureEnvironment() -> ExitCode? {
+    // Configure the `Current Environment`
+    guard CommandLine.argc == 2 || CommandLine.argc == 3 else {
+        printToStdErr("usage -- TextRulesToJSON <TextRulesPath> [<LinterSpecificationPath>]")
+        return .usage
+    }
+
+    let inputPath = CommandLine.arguments[1]
+    guard FileManager.default.fileExists(atPath: inputPath) else {
+        printToStdErr("rules file not found: \(inputPath)")
+        return .inputFileNotFound
+    }
+
+    switch contentsOf(path: inputPath) {
+    case let .failed(error):
+        printToStdErr("reading input failed: \(error)")
+        return .readingInputFileFailed
+    case let .success(contents):
+        Current.input = contents
+    }
+
+    guard CommandLine.argc == 3 else {
+        return nil
+    }
+
+    let lintPath = CommandLine.arguments[2]
+    guard FileManager.default.fileExists(atPath: lintPath) else {
+        printToStdErr("linter specification file not found: \(lintPath)")
+        return .linterFileNotFound
+    }
+
+    switch dataOf(path: lintPath) {
+    case let .failed(error):
+        printToStdErr("reading linter specification file failed: \(error)")
+        return .readingLinterFileFailed
+    case let .success(data):
+        let decoder = JSONDecoder()
+        do {
+            Current.linterSpecification = try decoder.decode(LinterSpecification.self, from: data)
+            return nil
+        } catch {
+            printToStdErr("decoding linter specification file failed: \(error)")
+            return .decodingLinterFileFailed
+        }
+    }
+}
+
+func convert() -> ExitCode {
+    switch parse(humanRuleFileContents: Current.input) {
+    case .failed(let errors):
+        errors.forEach { printToStdErr("parsing input failed. line: \($0.line), rule: \($0.line), error: \($0.error)") }
+        return .parsingFailed
+    case .success(let values):
+        let errors = linter(parsed: values, spec: Current.linterSpecification)
+        guard errors.isEmpty else {
+            errors
+                .sorted { lhs, rhs in
+                    switch (lhs.0?.lineNumber ?? 0, rhs.0?.lineNumber ?? 0) {
+                    case let (l, r) where l < r: return true
+                    case let (l, r) where l == r: return lhs.1 < rhs.1
+                    default: return false
+                    }
+                }
+                .forEach { printToStdErr(($0.0.map { "line \($0.lineNumber): " } ?? "") + "\($0.1)") }
+            return .invalidRules
+        }
+        switch jsonData(rules: values.map { $0.rule }) {
+        case let .failed(error):
+            printToStdErr("encoding rules to JSON failed: \(error)")
+            return .encodingToJSONFailed
+        case let .success(data):
+            FileHandle.standardOutput.write(data)
+            return .success
+        }
+    }
+}
+
+func jsonData(rules: [Rule]) -> Rules.Result<Error, Data> {
+    do {
+        return .success(try JSONEncoder().encode(rules))
+    } catch {
+        return .failed(error)
+    }
+}
+
+func main() -> ExitCode {
+    return configureEnvironment()
+        ?? convert()
+}
+
+exit(main().rawValue)


### PR DESCRIPTION
Rule Linting was added to the TextRulesToJSON program. Linting becomes a step of the .rules to .json conversion process.

- better error handling in TextRulesToJSON, support for linting added
- finds rules with obviously invalid predicates (comparing true/false using one of < <= > >=)
- set of accepted RHS questions along with their expected answer type
- set of accepted questions in LHS expressions along with their expected answer type
- check for duplicate rules (rudimentary right now due to Rule's lack of Hashable)

Test coverage needs to improve further.

Example output:

```
TextRulesToJSON: no fallback rule found for favouritePlayer
TextRulesToJSON: line 1: the answer for favouriteTeam rules must be one of: Capitals, Oilers, Lightning, Canucks
TextRulesToJSON: line 2: lhs question city not found in the linter file
TextRulesToJSON: line 3: lhs question city not found in the linter file
TextRulesToJSON: line 4: firstName may only be compared to one of: Jim, Cheryl, Cyan, Xavier
TextRulesToJSON: line 4: lhs question city not found in the linter file
TextRulesToJSON: line 5: invalid predicate: boolean values are not comparable
TextRulesToJSON: line 5: rhs question shouldnot not found in the linter file
TextRulesToJSON: line 5: type mismatch, firstName should be a string but it is being compared to a bool
TextRulesToJSON: line 6: invalid predicate: boolean values are not comparable
TextRulesToJSON: line 6: rhs question shouldnot not found in the linter file
TextRulesToJSON: line 7: duplicate rule found
TextRulesToJSON: line 7: invalid predicate: boolean values are not comparable
TextRulesToJSON: line 7: rhs question shouldnot not found in the linter file
TextRulesToJSON: line 8: rhs question kid not found in the linter file
```

This output was produced for this input:

Rules file:

```
0: true => favouriteTeam = X
10: (firstName = 'Jim' AND lastName = 'Roepcke') OR (city = 'Edmonton') => favouriteTeam = Oilers
10: (firstName = 'Xavier' AND lastName = 'Roepcke') OR (city = 'Tampa Bay') => favouriteTeam = Lightning
10: (firstName = 'Bob' AND lastName = 'Roepcke') OR (city = 'Tampa Bay') => favouriteTeam = Lightning
10: firstName < true => shouldnot = work
10: true < true => shouldnot = workeither
10: true < true => shouldnot = workeither
10: age < 10 => kid = true
```

Linter specification file:

```javascript
{
  "lhs": {
    "firstName": ["Jim", "Cheryl", "Cyan", "Xavier"],
    "lastName": "string",
    "age": "int"
  },
  "rhs": {
    "favouriteTeam": ["Capitals", "Oilers", "Lightning", "Canucks"],
    "favouritePlayer": "any"
  }
}
```
