### PR TITLE
Skip Invalid Rule Instead of Skipping All Remaining Candidate Rules

### DIFF
--- a/Example/Rules.xcodeproj/project.pbxproj
+++ b/Example/Rules.xcodeproj/project.pbxproj
@@ -295,7 +295,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Rules_Example/Pods-Rules_Example-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Rules_Example/Pods-Rules_Example-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Rules/Rules.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
@@ -304,7 +304,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Rules_Example/Pods-Rules_Example-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Rules_Example/Pods-Rules_Example-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9FA40209A20704CA1B8B8135 /* [CP] Embed Pods Frameworks */ = {
@@ -313,7 +313,7 @@
 			files = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-Rules_Tests/Pods-Rules_Tests-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-Rules_Tests/Pods-Rules_Tests-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Nimble/Nimble.framework",
 				"${BUILT_PRODUCTS_DIR}/Quick/Quick.framework",
 			);
@@ -324,7 +324,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-Rules_Tests/Pods-Rules_Tests-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Rules_Tests/Pods-Rules_Tests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		B2150500D24D321407B3FA7B /* [CP] Check Pods Manifest.lock */ = {

--- a/Example/Rules.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Rules.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/Rules.xcodeproj/xcshareddata/xcschemes/Rules-Example.xcscheme
+++ b/Example/Rules.xcodeproj/xcshareddata/xcschemes/Rules-Example.xcscheme
@@ -40,8 +40,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "607FACCF1AFB9204008FA782"
+            BuildableName = "Rules_Example.app"
+            BlueprintName = "Rules_Example"
+            ReferencedContainer = "container:Rules.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -54,17 +63,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "607FACCF1AFB9204008FA782"
-            BuildableName = "Rules_Example.app"
-            BlueprintName = "Rules_Example"
-            ReferencedContainer = "container:Rules.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -86,8 +84,6 @@
             ReferencedContainer = "container:Rules.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Example/Tests/FactsTests.swift
+++ b/Example/Tests/FactsTests.swift
@@ -57,6 +57,7 @@ class FactsTests: QuickSpec {
                 brain = nil
             }
 
+            // MARK: one rule
             context("one rule") {
 
                 beforeEach {
@@ -92,7 +93,7 @@ class FactsTests: QuickSpec {
                     }
                 }
             }
-
+            // MARK: two mutually-exclusive rules sharing the same priority & predicate size
             context("two mutually-exclusive rules sharing the same priority & predicate size") {
 
                 beforeEach {
@@ -115,7 +116,7 @@ class FactsTests: QuickSpec {
                     }
                 }
             }
-
+            // MARK: two non-mutually-exclusive rules sharing the same priority & predicate size
             context("two non-mutually-exclusive rules sharing the same priority & predicate size") {
 
                 beforeEach {
@@ -142,7 +143,45 @@ class FactsTests: QuickSpec {
                     }
                 }
             }
+            // MARK: two non-mutually-exclusive rules, one with unsupported predicate
+            context("two non-mutually-exclusive rules, one with unsupported predicate") {
 
+                beforeEach {
+                    let rule1 = Rule(
+                        priority: 1,
+                        predicate: .true,
+                        question: "question",
+                        answer: "answer1",
+                        assignment: nil
+                    )
+
+                    let rule2 = Rule(
+                        priority: 1,
+                        predicate: .comparison(lhs: .question("foo"), op: .isEqualTo, rhs: .question("bar")),
+                        question: "question",
+                        answer: "answer1",
+                        assignment: nil
+                    )
+                    brain?.add(rules: [rule1, rule2])
+                }
+
+                afterEach {
+                    brain = nil
+                }
+
+                it("answers the question") {
+                    guard let brain = brain else { return fail() }
+                    var facts = Facts.init(brain: brain, cacheAnswers: false)
+                    let result = facts.ask(question: "question")
+                    switch result {
+                    case let .failed(error):
+                        fail("asking \"question\" should not have failed. received: \(error)")
+                    case let .success(answer):
+                        expect(answer.answer) == Facts.Answer.init(stringLiteral: "answer1")
+                    }
+                }
+            }
+            //MARK: two pairs of non-mutually-exclusive rules sharing the same priority & predicate size
             context("two pairs of non-mutually-exclusive rules sharing the same priority & predicate size") {
 
                 beforeEach {

--- a/Example/Tests/FactsTests.swift
+++ b/Example/Tests/FactsTests.swift
@@ -79,6 +79,18 @@ class FactsTests: QuickSpec {
                         expect(ambiguousRules).to(beEmpty())
                     }
                 }
+
+                it("reports an error when asking an invalid question") {
+                    guard let brain = brain else { return fail() }
+                    var facts = Facts.init(brain: brain, cacheAnswers: false)
+                    let result = facts.ask(question: "foo")
+                    switch result {
+                    case let .failed(error):
+                        expect(error) == .noRuleFound(question: "foo")
+                    case .success:
+                        fail("asking \"question\" should have failed.")
+                    }
+                }
             }
 
             context("two mutually-exclusive rules sharing the same priority & predicate size") {

--- a/Rules/Sources/Rules/Brain.swift
+++ b/Rules/Sources/Rules/Brain.swift
@@ -62,8 +62,10 @@ public struct Brain {
         }
         for (rule, rulePredicateSize) in rulesForQuestion where shouldContinue(rule: rule) {
             switch rule.predicate.matches(given: &facts) {
-            case .failed(let error):
-                return .failed(.candidateEvaluationFailed(error))
+            case .failed:
+                // Predicate failed, so skip this rule
+                // but don't return error because there may be other valid candidates
+                break // break the switch, not the loop!
             case .success(let evaluation) where evaluation.value:
                 candidates.append((rule, rulePredicateSize, evaluation.dependencies, evaluation.ambiguousRules))
             case .success:


### PR DESCRIPTION
If you have a rule that has a predicate that is invalid, the Brain was skipping all remaining valid rules and reporting that no rule was found.

```
10: field == 'oneline' => fieldStyle = onelineBase
20: field == 'oneline' AND screen == 'small' => fieldStyle = headlineOtherNewsRed
30: field == 'oneline' AND screen == 'small' AND foo == 'bar' => fieldStyle = headlineOtherNewsBlue
```

The above code was causing the rule engine to report that no match was found for small screens because the `foo` predicate was unknown to the engine. Instead of just ignoring that rule and falling back to the 2nd rule, it was saying no match was found. 

This fix will fallback to another candidate if it exists.

Note that Cocoapods 1.84 changed some project files when I ran pod install to set up the project. I can remove those changes if you'd like.
